### PR TITLE
Bump fs-extra version to ^0.26.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "findup": "^0.1.5",
-    "fs-extra": "^0.16.3",
+    "fs-extra": "^0.26.6",
     "lodash.merge": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix WARN

```
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```