### PR TITLE
[FIX] Fix issue where falsey property is returned as undefined

### DIFF
--- a/lib/yam.js
+++ b/lib/yam.js
@@ -44,7 +44,7 @@ Yam.prototype.getAll = function getAll() {
 Yam.prototype.get = function get(key) {
   var value = this.options[key];
 
-  return value ? value : undefined;
+  return value !== undefined ? value : undefined;
 };
 
 module.exports = Yam;

--- a/test/fixtures/primary/.test
+++ b/test/fixtures/primary/.test
@@ -1,3 +1,4 @@
 {
-  "foo": "bar"
+  "foo": "bar",
+  "falsey": false
 }

--- a/test/yam-test.js
+++ b/test/yam-test.js
@@ -43,6 +43,15 @@ describe('Yam', function() {
 
       equal(yam.get('durp'), undefined);
     });
+
+    it('returns `false` if the value is false', function() {
+      yam = new Yam('test', {
+        primary:   'test/fixtures/primary/',
+        secondary: 'test/fixtures/secondary/'
+      });
+
+      equal(yam.get('falsey'), false);
+    });
   });
 
   describe('constructor', function() {
@@ -60,7 +69,8 @@ describe('Yam', function() {
 
       deepEqual(yam.options, {
         foo: 'bar',
-        baz: 5
+        baz: 5,
+        falsey: false
       });
     });
   });


### PR DESCRIPTION
I discovered an issue while working on https://github.com/ember-cli/ember-cli/issues/7429 where if you have a falsey property value, it gets returned as `undefined`.


``` js
/* .test
{
  "falsey": false
}
*/

yam.get('falsey') => undefined
```